### PR TITLE
CI: Remove unnecessary "gem install bundler"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           v2-linux-2.3-{{ checksum rmagick.gemspec }}
     - name: Build and test with Rake
       run: |
-        gem install bundler
         bundle install --path=vendor/bundle --jobs 4 --retry 3
         STYLE_CHECKS=true bundle exec rubocop
 
@@ -68,7 +67,6 @@ jobs:
           v2-linux-${{ matrix.ruby-version }}-{{ checksum rmagick.gemspec }}
     - name: Build and test with Rake
       run: |
-        gem install bundler
         bundle install --path=vendor/bundle --jobs 4 --retry 3
         bundle exec rake
 


### PR DESCRIPTION
`bundler` will be installed at https://github.com/Watson1978/rmagick/blob/67608046793f1c421fb0658227a0dde80918fa05/before_install_linux.sh#L5